### PR TITLE
trailing whitespace in template configfile in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Max threads              = 8
 
 Structural variation:
 -----------------------------
-VCF input                = 
+VCF input                =
 Foreign sequences        =
 
 Deletions                = 0


### PR DESCRIPTION
I have been trying to run simit for the past day while copy pasting the template configfile in the README, I have discovered a trailing whitespace that breaks the regex and the code and does not allow to simulate the requested number of SVs

it's just a whitespace after the = in the 'VCF input' line