### PR TITLE
add missing ##FORMAT line to Sim-it1.4.4.pl

### DIFF
--- a/Sim-it1.4.4.pl
+++ b/Sim-it1.4.4.pl
@@ -1348,6 +1348,7 @@ if ($SV_input eq "yes")
     print OUTPUT_VCF_FULL "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n";
     print OUTPUT_VCF_FULL "##FORMAT=<ID=DR,Number=1,Type=Integer,Description=\"# High-quality reference reads\">\n";
     print OUTPUT_VCF_FULL "##FORMAT=<ID=DV,Number=1,Type=Integer,Description=\"# High-quality variant reads\">\n";
+    print OUTPUT_VCF_FULL "##FORMAT=<ID=CN,Number=1,Type=Integer,Description=\"Copy Number\">\n";
     print OUTPUT_VCF_FULL "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tsample1\n";
 
 #--------------------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Hi Nicolas, 

while I was working with Sim-it I noticed that there is a missing ##FORMAT line in the header. 

the DUP created with simit do have the field, I'll paste one as an example:

`NC_088327.1     15203000        611     C       <DUP:TANDEM>    .       PASS    SVTYPE=DUP:TANDEM;SVLEN=378     GT:CN   1/0:7`

it's just missing from the header. 

This causes some issues in downstream analyses, for example while using Truvari to compute precision and recall (it searches for the CN field but it does not find it). 
